### PR TITLE
Add OpenAI Codex engine option

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,5 +1,8 @@
 # PocketDev Containerized AI Developer Integration Guide
 
+PocketDev supports both **Claude Code** and **OpenAI Codex** agents. See
+[`docs/codex-integration.md`](docs/codex-integration.md) for details on using Codex.
+
 ## Quick Start
 
 ### 1. Install Dependencies

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A working prototype that demonstrates:
    - All heavy lifting done by OpenAI's infrastructure
 
 3. **OpenAI Integration**
-   - Each engineer is an OpenAI Assistant
+   - Engineers can run using Claude Code or OpenAI Codex
    - Tasks run on OpenAI's compute
    - Status updates stream back to mobile
 

--- a/docker/ai-developer/Dockerfile
+++ b/docker/ai-developer/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && apt-get install -y \
 # Install Claude CLI
 RUN npm install -g @anthropic-ai/claude-code
 
+# Install Codex CLI
+RUN npm install -g @openai/codex
+
 # Install common development tools
 RUN npm install -g \
     typescript \

--- a/docker/ai-developer/entrypoint.sh
+++ b/docker/ai-developer/entrypoint.sh
@@ -38,6 +38,8 @@ log_info "Starting AI Developer Container"
 log_info "Task ID: ${TASK_ID:-unknown}"
 log_info "Engineer Role: ${ENGINEER_ROLE:-fullstack}"
 log_info "Model: ${MODEL:-claude-3-5-sonnet-latest}"
+ENGINE_TYPE="${ENGINE_TYPE:-claude}"
+log_info "Engine type: $ENGINE_TYPE"
 
 # Validate required environment variables
 if [ -z "$REPO_URL" ]; then
@@ -50,13 +52,18 @@ if [ -z "$TASK_DESCRIPTION" ]; then
     exit 1
 fi
 
-if [ -z "$CLAUDE_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
-    log_error "CLAUDE_API_KEY or ANTHROPIC_API_KEY environment variable is required"
-    exit 1
+if [ "$ENGINE_TYPE" = "codex" ]; then
+    if [ -z "$OPENAI_API_KEY" ]; then
+        log_error "OPENAI_API_KEY environment variable is required"
+        exit 1
+    fi
+else
+    if [ -z "$CLAUDE_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+        log_error "CLAUDE_API_KEY or ANTHROPIC_API_KEY environment variable is required"
+        exit 1
+    fi
+    export ANTHROPIC_API_KEY="${CLAUDE_API_KEY:-$ANTHROPIC_API_KEY}"
 fi
-
-# Set API key for Claude
-export ANTHROPIC_API_KEY="${CLAUDE_API_KEY:-$ANTHROPIC_API_KEY}"
 
 # Function to handle Git authentication
 setup_git_auth() {
@@ -120,6 +127,30 @@ run_claude() {
         log_error "Claude execution failed"
         cat "$output_file"
         return 1
+    fi
+}
+
+# Function to run Codex
+run_codex() {
+    local prompt="$1"
+    local output_file="$2"
+
+    local codex_args=("--model" "${MODEL:-codex-mini-latest}" -q "$prompt")
+    if codex "${codex_args[@]}" > "$output_file" 2>&1; then
+        return 0
+    else
+        log_error "Codex execution failed"
+        cat "$output_file"
+        return 1
+    fi
+}
+
+# Wrapper to run the selected engine
+run_agent() {
+    if [ "$ENGINE_TYPE" = "codex" ]; then
+        run_codex "$1" "$2" "$3"
+    else
+        run_claude "$1" "$2" "$3"
     fi
 }
 
@@ -200,7 +231,7 @@ $ACCEPTANCE_CRITERIA
 
 First, understand the project structure, then design tests that will validate the implementation."
     
-    if ! run_claude "$analyze_prompt" "/workspace/logs/analysis.json"; then
+    if ! run_agent "$analyze_prompt" "/workspace/logs/analysis.json"; then
         error_message="Failed to analyze codebase"
         save_results "$success" "$error_message" "" "$start_time"
         exit 1
@@ -209,7 +240,7 @@ First, understand the project structure, then design tests that will validate th
     # Step 2: Write tests first (TDD)
     local test_prompt="Now write comprehensive tests for the feature. Follow TDD principles - write failing tests first that cover all acceptance criteria."
     
-    if ! run_claude "$test_prompt" "/workspace/logs/write_tests.json" true; then
+    if ! run_agent "$test_prompt" "/workspace/logs/write_tests.json" true; then
         error_message="Failed to write tests"
         save_results "$success" "$error_message" "" "$start_time"
         exit 1
@@ -218,7 +249,7 @@ First, understand the project structure, then design tests that will validate th
     # Step 3: Implement the feature
     local implement_prompt="Now implement the feature to make all tests pass. Focus on clean, maintainable code that follows the project's patterns."
     
-    if ! run_claude "$implement_prompt" "/workspace/logs/implementation.json" true; then
+    if ! run_agent "$implement_prompt" "/workspace/logs/implementation.json" true; then
         error_message="Failed to implement feature"
         save_results "$success" "$error_message" "" "$start_time"
         exit 1
@@ -241,7 +272,7 @@ First, understand the project structure, then design tests that will validate th
                 log_warning "Tests failed, asking Claude to fix..."
                 local fix_prompt="The tests failed. Please analyze the errors and fix the implementation to make all tests pass."
                 
-                if ! run_claude "$fix_prompt" "/workspace/logs/fix_iteration_$iteration.json" true; then
+                if ! run_agent "$fix_prompt" "/workspace/logs/fix_iteration_$iteration.json" true; then
                     error_message="Failed to fix test failures"
                     break
                 fi
@@ -262,7 +293,7 @@ First, understand the project structure, then design tests that will validate th
         
         # Generate commit message
         local commit_prompt="Generate a concise, descriptive commit message for these changes. Include what was done and why."
-        run_claude "$commit_prompt" "/workspace/logs/commit_message.json" true
+        run_agent "$commit_prompt" "/workspace/logs/commit_message.json" true
         
         local commit_message=$(jq -r '.result // "feat: implement requested feature"' /workspace/logs/commit_message.json)
         

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,0 +1,5 @@
+# Codex Integration
+
+PocketDev now supports using the OpenAI Codex CLI as an alternative to Claude Code. When registering an engineer you can specify `engineType: "codex"` and tasks will be executed with the Codex CLI. The Docker image now installs `@openai/codex` and the container entrypoint selects the CLI based on the `ENGINE_TYPE` environment variable.
+
+To run Codex tasks locally set `ENGINE_TYPE=codex` and provide `OPENAI_API_KEY`.

--- a/local-backend/container-routes.js
+++ b/local-backend/container-routes.js
@@ -26,6 +26,19 @@ router.get('/api/container/engineers', (req, res) => {
   res.json(engineers);
 });
 
+// Create a new container-based engineer
+router.post('/api/container/engineers', (req, res) => {
+  const { name, role, engineType = 'claude', systemPrompt } = req.body;
+  if (!name || !role) {
+    return res.status(400).json({ error: 'Missing required fields: name, role' });
+  }
+
+  const id = `${role}-${Date.now()}`;
+  containerManager.registerEngineer(id, { name, role, engineType, systemPrompt });
+  const engineer = containerManager.getEngineerStatus(id);
+  res.json({ success: true, engineer });
+});
+
 // Get specific engineer status
 router.get('/api/container/engineers/:id', (req, res) => {
   const engineer = containerManager.getEngineerStatus(req.params.id);

--- a/local-backend/host-codex.js
+++ b/local-backend/host-codex.js
@@ -1,0 +1,187 @@
+import { exec, spawn } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import fs from 'fs/promises';
+
+const execAsync = promisify(exec);
+
+export class HostCodexManager {
+  constructor() {
+    this.workspacesPath = path.join(process.cwd(), '..', 'workspaces');
+  }
+
+  /**
+   * Execute a task using host Codex in a specific workspace
+   */
+  async executeTask(engineerId, task, role, model = 'sonnet') {
+    // Log to stderr so it shows in console
+    console.error(`[HostCodexManager] Executing task for ${role} engineer`);
+    console.error(`[HostCodexManager] Task: ${task}`);
+    console.error(`[HostCodexManager] Model: ${model}`);
+    
+    const workspacePath = path.join(this.workspacesPath, role);
+    console.error(`[HostCodexManager] Workspace path: ${workspacePath}`);
+    
+    // Add context to help Codex understand file creation is authorized
+    const enhancedTask = `CONTEXT: You are an AI developer on the PocketDev platform. The user is explicitly requesting code/file content.
+    
+USER REQUEST: ${task}
+
+INSTRUCTIONS: Provide the complete code/content requested. If asked for a file like README.md, provide the full markdown content in a code block.`;
+    
+    // Ensure workspace exists
+    await fs.mkdir(workspacePath, { recursive: true });
+
+    return new Promise((resolve, reject) => {
+      console.error(`[HostCodexManager] Starting codex process...`);
+      console.error(`[HostCodexManager] API Key present: ${!!process.env.OPENAI_API_KEY}`);
+      
+      // Use spawn for better control
+      // Debug: log the exact command being run
+      const args = [enhancedTask, '--model', model, '-q'];
+      console.error(`[HostCodexManager] Using enhanced prompt with context`);
+      console.error(`[HostCodexManager] Working directory: ${workspacePath}`);
+      console.error(`[HostCodexManager] API Key: ${process.env.OPENAI_API_KEY?.substring(0, 10)}...`);
+      
+      const claudeProcess = spawn('codex', args, {
+        cwd: workspacePath,
+        env: {
+          ...process.env,
+          OPENAI_API_KEY: process.env.OPENAI_API_KEY
+        },
+        stdio: ['pipe', 'pipe', 'pipe'] // Explicitly set stdio
+      });
+      
+      // Close stdin immediately since we're not sending any input
+      claudeProcess.stdin.end();
+
+      let stdout = '';
+      let stderr = '';
+      let processStarted = false;
+
+      claudeProcess.on('spawn', () => {
+        processStarted = true;
+        console.error('[HostCodexManager] Process spawned successfully');
+      });
+
+      claudeProcess.stdout.on('data', (data) => {
+        const chunk = data.toString();
+        stdout += chunk;
+        console.error(`[HostCodexManager] Stdout chunk (${chunk.length} chars): ${chunk.substring(0, 100)}...`);
+      });
+
+      claudeProcess.stderr.on('data', (data) => {
+        const chunk = data.toString();
+        stderr += chunk;
+        console.error('[HostCodexManager] Codex stderr chunk:', chunk);
+      });
+
+      claudeProcess.on('error', (error) => {
+        console.error('[HostCodexManager] Process error:', error);
+        reject(error);
+      });
+
+      claudeProcess.on('close', (code) => {
+        clearTimeout(timeout); // Clear the timeout since process finished
+        console.error(`[HostCodexManager] Process exited with code ${code}`);
+        console.error(`[HostCodexManager] Stdout length: ${stdout.length}`);
+        
+        if (code !== 0) {
+          resolve({
+            success: false,
+            error: stderr || `Process exited with code ${code}`
+          });
+          return;
+        }
+
+        // Parse JSON output
+        try {
+          const result = JSON.parse(stdout);
+          console.error(`[HostCodexManager] Parsed result:`, result);
+          
+          resolve({
+            success: true,
+            result: result.result || result.content || result.text || stdout,
+            sessionId: result.session_id || result.sessionId,
+            cost: result.cost || result.total_cost,
+            rawOutput: stdout
+          });
+        } catch (parseError) {
+          console.error(`[HostCodexManager] Failed to parse JSON, returning raw output`);
+          // If JSON parsing fails, return raw output
+          resolve({
+            success: true,
+            result: stdout,
+            output: stdout
+          });
+        }
+      });
+
+      // Add a timeout - 10 minutes should be enough for most tasks
+      const timeoutMs = 10 * 60 * 1000; // 10 minutes
+      const timeout = setTimeout(() => {
+        console.error(`[HostCodexManager] Timeout - killing process after ${timeoutMs/1000} seconds`);
+        claudeProcess.kill();
+        reject(new Error(`Codex process timed out after ${timeoutMs/1000} seconds`));
+      }, timeoutMs);
+    }).catch(error => {
+      console.error('[HostCodexManager] Execution error:', error);
+      return {
+        success: false,
+        error: error.message || 'Unknown error'
+      };
+    });
+  }
+
+  /**
+   * Start interactive Codex session in a workspace
+   */
+  async startInteractiveSession(engineerId, role) {
+    const workspacePath = path.join(this.workspacesPath, role);
+    
+    // Ensure workspace exists
+    await fs.mkdir(workspacePath, { recursive: true });
+
+    // Start Codex in the workspace
+    const claudeProcess = spawn('codex', [], {
+      cwd: workspacePath,
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY
+      }
+    });
+
+    return {
+      process: claudeProcess,
+      workspacePath
+    };
+  }
+
+  /**
+   * List files in workspace
+   */
+  async listWorkspaceFiles(role) {
+    const workspacePath = path.join(this.workspacesPath, role);
+    try {
+      const files = await fs.readdir(workspacePath);
+      return files;
+    } catch (error) {
+      return [];
+    }
+  }
+
+  /**
+   * Get workspace info
+   */
+  async getWorkspaceInfo(role) {
+    const workspacePath = path.join(this.workspacesPath, role);
+    const files = await this.listWorkspaceFiles(role);
+    
+    return {
+      path: workspacePath,
+      files: files,
+      exists: files.length > 0
+    };
+  }
+}

--- a/local-backend/lib/container-orchestrator.js
+++ b/local-backend/lib/container-orchestrator.js
@@ -44,11 +44,19 @@ class ContainerOrchestrator {
         TASK_DESCRIPTION: task.description,
         ACCEPTANCE_CRITERIA: JSON.stringify(task.acceptanceCriteria || []),
         TEST_FRAMEWORK: task.testFramework || 'jest',
-        CLAUDE_API_KEY: process.env.ANTHROPIC_API_KEY,
         ENGINEER_ROLE: task.engineerRole || 'fullstack',
         MODEL: task.model || 'claude-3-5-sonnet-latest',
-        MAX_ITERATIONS: task.maxIterations || '5'
+        MAX_ITERATIONS: task.maxIterations || '5',
+        ENGINE_TYPE: task.engineType || 'claude'
       };
+
+      if (env.ENGINE_TYPE === 'codex') {
+        if (process.env.OPENAI_API_KEY) {
+          env.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+        }
+      } else {
+        env.CLAUDE_API_KEY = process.env.ANTHROPIC_API_KEY;
+      }
 
       // Add Git credentials if provided
       if (task.repository.credentials) {

--- a/local-backend/lib/container-task-manager.js
+++ b/local-backend/lib/container-task-manager.js
@@ -10,27 +10,39 @@ class ContainerTaskManager {
 
   async init() {
     await this.orchestrator.init();
-    
+
     // Initialize default engineers
     this.registerEngineer('frontend-1', {
       name: 'Frontend Engineer',
       role: 'frontend',
+      engineType: 'claude',
       specialties: ['React', 'TypeScript', 'UI/UX'],
       systemPrompt: 'You are a senior frontend engineer specializing in React and TypeScript. Focus on component architecture, accessibility, and user experience.'
     });
 
     this.registerEngineer('backend-1', {
-      name: 'Backend Engineer', 
+      name: 'Backend Engineer',
       role: 'backend',
+      engineType: 'claude',
       specialties: ['Node.js', 'Python', 'API Design'],
       systemPrompt: 'You are a backend architect specializing in scalable APIs. Focus on security, performance, and proper error handling.'
     });
 
     this.registerEngineer('devops-1', {
       name: 'DevOps Engineer',
-      role: 'devops', 
+      role: 'devops',
+      engineType: 'claude',
       specialties: ['Docker', 'Kubernetes', 'CI/CD'],
       systemPrompt: 'You are a DevOps specialist. Focus on automation, monitoring, and infrastructure as code.'
+    });
+
+    // Example Codex engineer
+    this.registerEngineer('codex-1', {
+      name: 'Codex Engineer',
+      role: 'fullstack',
+      engineType: 'codex',
+      specialties: ['General'],
+      systemPrompt: 'You are an AI engineer powered by OpenAI Codex.'
     });
   }
 
@@ -40,6 +52,7 @@ class ContainerTaskManager {
   registerEngineer(id, config) {
     this.engineers.set(id, {
       id,
+      engineType: config.engineType || 'claude',
       ...config,
       status: 'idle',
       currentTask: null,
@@ -86,7 +99,8 @@ class ContainerTaskManager {
         description: taskConfig.description,
         acceptanceCriteria: taskConfig.acceptanceCriteria,
         testFramework: taskConfig.testFramework,
-        model: taskConfig.model
+        model: taskConfig.model,
+        engineType: engineer.engineType
       });
 
       // Update task with results

--- a/local-backend/server.js
+++ b/local-backend/server.js
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { DockerClaudeManager } from './docker-claude.js';
 import { HostClaudeManager } from './host-claude.js';
+import { HostCodexManager } from './host-codex.js';
 import { CodeExtractor } from './lib/code-extractor.js';
 import containerRoutes from './container-routes.js';
 
@@ -34,6 +35,7 @@ const activeProcesses = new Map();
 // Claude managers
 const dockerManager = new DockerClaudeManager();
 const hostManager = new HostClaudeManager();
+const hostCodexManager = new HostCodexManager();
 const codeExtractor = new CodeExtractor();
 
 // In-memory mock data for local development
@@ -42,6 +44,7 @@ const mockEngineers = [
     id: '1',
     name: 'Claude Frontend',
     role: 'frontend',
+    engineType: 'claude',
     status: 'idle',
     last_update: new Date().toISOString(),
     created_at: new Date().toISOString()
@@ -50,6 +53,7 @@ const mockEngineers = [
     id: '2',
     name: 'Claude Backend',
     role: 'backend',
+    engineType: 'claude',
     status: 'idle',
     last_update: new Date().toISOString(),
     created_at: new Date().toISOString()
@@ -58,6 +62,16 @@ const mockEngineers = [
     id: '3',
     name: 'Claude DevOps',
     role: 'devops',
+    engineType: 'claude',
+    status: 'idle',
+    last_update: new Date().toISOString(),
+    created_at: new Date().toISOString()
+  },
+  {
+    id: '4',
+    name: 'Codex Engineer',
+    role: 'fullstack',
+    engineType: 'codex',
     status: 'idle',
     last_update: new Date().toISOString(),
     created_at: new Date().toISOString()
@@ -180,7 +194,11 @@ app.post('/api/assign-task', async (req, res) => {
     if (executionMode === 'docker') {
       result = await dockerManager.executeTask(engineerId, task, engineer.role, model);
     } else if (executionMode === 'host') {
-      result = await hostManager.executeTask(engineerId, task, engineer.role, model);
+      if (engineer.engineType === 'codex') {
+        result = await hostCodexManager.executeTask(engineerId, task, engineer.role, model);
+      } else {
+        result = await hostManager.executeTask(engineerId, task, engineer.role, model);
+      }
     } else {
       // Local execution (original method)
       result = await executeClaudeTask(engineerId, task, engineer.role, model);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -5,6 +5,7 @@ export interface Engineer {
   id: string;
   name: string;
   role: EngineerRole;
+  engineType?: 'claude' | 'codex';
   status: EngineerStatus;
   current_task?: string;
   progress?: number;


### PR DESCRIPTION
## Summary
- support choosing `engineType` when registering engineers
- add Codex CLI to Docker image and select engine via `ENGINE_TYPE`
- implement `HostCodexManager` for host mode
- expose API route to create container engineers with `engineType`
- document Codex integration

## Testing
- `npm test --prefix local-backend` *(fails: Validation Error: extensionsToTreatAsEsm)*

------
https://chatgpt.com/codex/tasks/task_e_6842f70ebe748328a99991d54980e831